### PR TITLE
Add support for copying url from extension badge popup.

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,6 +12,7 @@ async function delayClearBadgeText(ms) {
 chrome.runtime.onInstalled.addListener(function() {
     console.log("Installed");
     chrome.browserAction.setBadgeText({text: "⚡"});
+    delayClearBadgeText(5000)
 })
 
 chrome.runtime.onSuspend.addListener(function() {
@@ -22,6 +23,7 @@ chrome.runtime.onSuspend.addListener(function() {
 chrome.webRequest.onBeforeSendHeaders.addListener(
   function(details) {
     if (details.type == "xmlhttprequest" && details.url.includes("a.m3u8")) {
+      chrome.browserAction.setBadgeText({'text': details.url});
       console.log(details)
     }
     return {}

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     "http://*/*"
   ],
   "browser_action": {
-      "default_title":"GPVideo"
+      "default_title":"GPVideo",
+      "default_popup": "popup-url.html"
   },
   "background": {
        "scripts": ["background.js"],

--- a/popup-url.html
+++ b/popup-url.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <textarea id="url"></textarea>
+    <script src="popup-url.js"></script>
+  </body>
+</html>

--- a/popup-url.js
+++ b/popup-url.js
@@ -1,0 +1,13 @@
+'use strict';
+
+let textarea = document.getElementById('url');
+
+chrome.browserAction.getBadgeText({}, function(result) { textarea.value = result })
+
+textarea.onclick = function(element) {
+  let url = element.target;
+  url.focus();
+  url.select();
+  url.setSelectionRange(0,99999);
+  document.execCommand('copy');
+};


### PR DESCRIPTION
TODO: Make it so that clicking on the badge sends a message
to the background script.  The background script can then send
the url to the background video player.